### PR TITLE
Fix getDataFrame sorting typo

### DIFF
--- a/2_Code/RFM_v0.2.R
+++ b/2_Code/RFM_v0.2.R
@@ -93,7 +93,7 @@ getDataFrame <- function(df, startDate, endDate, tIDColName = "ID", tDateColName
 	newdf <- cbind(newdf, Recency)
 
 	# sort data frame by ID to fit the return order of table() and tapply()
-	newdf <- newdf[order(newdf[ , tDateColName]), ]
+	newdf <- newdf[order(newdf[ , tIDColName]), ]
 
 	# calc. the Frequency
 	tmp <- as.data.frame(table(df[ , tIDColName]))


### PR DESCRIPTION
Based on the comment above line 96, newdf is meant to sorted by the ID column and is mistakenly being sorted by the Date column which is causing the Frequency and Monetary values to be associated with the wrong IDs when added to the data frame.